### PR TITLE
添加Do1e并增加Seatable支持

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('workers-site/package-lock.json') }}
       - run: npm i # 执行 Blogroll 的依赖安装
       - run: npm run gen # 相当于 node index.js，生成 opml.xml，opml.json 和 data.json
+        env:
+          SEATABLE_API_TOKEN: ${{ secrets.SEATABLE_API_TOKEN }}
       - run: npm run build
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Pull Request 规范：标题为自己的名字，内容可以是对自己和博�
 | A7R7's Notes | https://a7r7.me/index.xml | https://a7r7.me |
 | StrnasnX's Blog | https://stringmax.xyz/atom.xml | https://stringmax.xyz/ |
 | Yukino's Blog | https://02hyc.github.io/Blog.github.io/atom.xml | https://02hyc.github.io/Blog.github.io/ |
+| Do1e | https://www.do1e.cn/feed | https://www.do1e.cn |
 
 ## OPML
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const Parser = require('rss-parser');
 const parser = new Parser();
 // 引入 RSS 生成器
 const RSS = require('rss');
+// 引入 SeaTableAPI
+const { Base } = require('seatable-api');
 
 // 相关配置
 const opmlXmlContentTitle = 'NJU-LUG Blogroll';
@@ -16,12 +18,12 @@ const opmlXmlPath = './web/public/opml.xml';
 const rssXmlPath = './web/public/rss.xml';
 const opmlXmlContentOp = '<opml version="2.0">\n  <head>\n    <title>' + opmlXmlContentTitle + '</title>\n  </head>\n  <body>\n\n';
 const opmlXmlContentEd = '\n  </body>\n</opml>';
-
+const seatableToken = process.env.SEATABLE_API_TOKEN;
 // 解析 README 中的表格，转为 JSON
 const pattern = /\| *([^\|]*) *\| *(http[^\|]*) *\| *(http[^\|]*) *\|/g;
 const readmeMdContent = fs.readFileSync(readmeMdPath, { encoding: 'utf-8' });
 // 生成 opml.json
-const opmlJson = [];
+let opmlJson = [];
 let resultArray;
 while ((resultArray = pattern.exec(readmeMdContent)) !== null) {
   opmlJson.push({
@@ -30,87 +32,118 @@ while ((resultArray = pattern.exec(readmeMdContent)) !== null) {
     htmlUrl: resultArray[3].trim()
   });
 }
-// 保存 opml.json 和 opml.xml
-fs.writeFileSync(opmlJsonPath, JSON.stringify(opmlJson, null, 2), { encoding: 'utf-8' });
-const opmlXmlContent = opmlXmlContentOp
-  + opmlJson.map((lineJson) => `  <outline title="${lineJson.title}" xmlUrl="${lineJson.xmlUrl}" htmlUrl="${lineJson.htmlUrl}" />\n`).join('')
-  + opmlXmlContentEd;
-fs.writeFileSync(opmlXmlPath, opmlXmlContent, { encoding: 'utf-8' });
 
-// 异步处理
+// 解析 SeaTable 中的表格，转为 JSON
+async function parseSeaTableToJson(opmlJson) {
+  const seatableBase = new Base({
+    server: "https://table.nju.edu.cn",
+    APIToken: seatableToken
+  });
+  await seatableBase.auth();
+  const tables = await seatableBase.getTables();
+  const rows = await seatableBase.listRows(tables[0]['name']);
+  rows.forEach(row => {
+    if (row['Name'] && (!opmlJson.some(item => item.title === row['Name'])) && row['RSS'].startsWith('http') && row['HTML'].startsWith('http')) {
+      opmlJson.push({
+        title: row['Name'],
+        xmlUrl: row['RSS'],
+        htmlUrl: row['HTML']
+      });
+    }
+  });
+  return opmlJson;
+}
 (async () => {
-  
-  // 用于存储各项数据
-  const dataJson = [];
-  
-  for (const lineJson of opmlJson) {
-    
+  // 如果定义 SeaTable Token，则将 SeaTable 中的数据合并到 opmlJson 中
+  if (seatableToken !== undefined && seatableToken !== '' && seatableToken !== null) {
     try {
-      
-      // 读取 RSS 的具体内容
-      const feed = await parser.parseURL(lineJson.xmlUrl);
-      
-      // 数组合并
-      dataJson.push.apply(dataJson, feed.items.filter((item) => item.title && item.content && item.pubDate).map((item) => {
-        const pubDate = new Date(item.pubDate);
-        return {
-          name: lineJson.title,
-          xmlUrl: lineJson.xmlUrl,
-          htmlUrl: lineJson.htmlUrl,
-          title: item.title,
-          link: item.link,
-          summary: item.summary ? item.summary : item.content,
-          pubDate: pubDate,
-          pubDateYYMMDD: pubDate.toISOString().split('T')[0]
-        }
-      }));
-      
+      opmlJson = await parseSeaTableToJson(opmlJson);
     } catch (err) {
-
-      // 网络超时，进行 Log 报告
       console.log(err);
-      console.log("-------------------------");
-      console.log("xmlUrl: " + lineJson.xmlUrl);
-      console.log("-------------------------");
-      
     }
   }
 
-  // 按时间顺序排序
-  dataJson.sort((itemA, itemB) => itemA.pubDate < itemB.pubDate ? 1 : -1);
-  // 默认为保存前 n 项的数据, 并保证不超过当前时间
-  const curDate = new Date();
-  const dataJsonSliced = dataJson.filter((item) => item.pubDate <= curDate).slice(0, Math.min(maxDataJsonItemsNumber, dataJson.length));
-  fs.writeFileSync(dataJsonPath, JSON.stringify(dataJsonSliced, null, 2), { encoding: 'utf-8' });
-  
-  // 生成 RSS 文件
-  var feed = new RSS({
-    title: 'NJU-LUG Blogroll',
-    description: '南京大学 Linux User Group 收集同学和校友们的 Blog',
-    feed_url: 'https://blogroll.njulug.org/rss.xml',
-    site_url: 'https://blogroll.njulug.org/',
-    image_url: 'https://blogroll.njulug.org/assets/logo.56c0d74c.png',
-    docs: 'https://blogroll.njulug.org/',
-    managingEditor: 'NJU-LUG',
-    webMaster: 'NJU-LUG',
-    copyright: '2022 NJU-LUG',
-    language: 'cn',
-    pubDate: dataJson[0].pubDate,
-    ttl: '60',
-  });
-  
-  for (let item of dataJsonSliced) {
-    feed.item({
-      title: item.title,
-      description: item.summary,
-      url: item.link, // link to the item
-      author: item.name, // optional - defaults to feed author property
-      date: item.pubDate.toISOString(), // any format that js Date can parse.
+  // 保存 opml.json 和 opml.xml
+  fs.writeFileSync(opmlJsonPath, JSON.stringify(opmlJson, null, 2), { encoding: 'utf-8' });
+  const opmlXmlContent = opmlXmlContentOp
+    + opmlJson.map((lineJson) => `  <outline title="${lineJson.title}" xmlUrl="${lineJson.xmlUrl}" htmlUrl="${lineJson.htmlUrl}" />\n`).join('')
+    + opmlXmlContentEd;
+  fs.writeFileSync(opmlXmlPath, opmlXmlContent, { encoding: 'utf-8' });
+
+  // 异步处理
+  (async () => {
+
+  // 用于存储各项数据
+    const dataJson = [];
+
+    for (const lineJson of opmlJson) {
+
+      try {
+
+        // 读取 RSS 的具体内容
+        const feed = await parser.parseURL(lineJson.xmlUrl);
+
+        // 数组合并
+        dataJson.push.apply(dataJson, feed.items.filter((item) => item.title && item.content && item.pubDate).map((item) => {
+          const pubDate = new Date(item.pubDate);
+          return {
+            name: lineJson.title,
+            xmlUrl: lineJson.xmlUrl,
+            htmlUrl: lineJson.htmlUrl,
+            title: item.title,
+            link: item.link,
+            summary: item.summary ? item.summary : item.content,
+            pubDate: pubDate,
+            pubDateYYMMDD: pubDate.toISOString().split('T')[0]
+          }
+        }));
+
+      } catch (err) {
+
+        // 网络超时，进行 Log 报告
+        console.log(err);
+        console.log("-------------------------");
+        console.log("xmlUrl: " + lineJson.xmlUrl);
+        console.log("-------------------------");
+
+      }
+    }
+
+    // 按时间顺序排序
+    dataJson.sort((itemA, itemB) => itemA.pubDate < itemB.pubDate ? 1 : -1);
+    // 默认为保存前 n 项的数据, 并保证不超过当前时间
+    const curDate = new Date();
+    const dataJsonSliced = dataJson.filter((item) => item.pubDate <= curDate).slice(0, Math.min(maxDataJsonItemsNumber, dataJson.length));
+    fs.writeFileSync(dataJsonPath, JSON.stringify(dataJsonSliced, null, 2), { encoding: 'utf-8' });
+
+    // 生成 RSS 文件
+    var feed = new RSS({
+      title: 'NJU-LUG Blogroll',
+      description: '南京大学 Linux User Group 收集同学和校友们的 Blog',
+      feed_url: 'https://blogroll.njulug.org/rss.xml',
+      site_url: 'https://blogroll.njulug.org/',
+      image_url: 'https://blogroll.njulug.org/assets/logo.56c0d74c.png',
+      docs: 'https://blogroll.njulug.org/',
+      managingEditor: 'NJU-LUG',
+      webMaster: 'NJU-LUG',
+      copyright: '2022 NJU-LUG',
+      language: 'cn',
+      pubDate: dataJson[0].pubDate,
+      ttl: '60',
     });
-  }
-  
-  // 保存 rss.xml 文件
-  const rssXmlContent = feed.xml();
-  fs.writeFileSync(rssXmlPath, rssXmlContent, { encoding: 'utf-8' });
-  
+
+    for (let item of dataJsonSliced) {
+      feed.item({
+        title: item.title,
+        description: item.summary,
+        url: item.link, // link to the item
+        author: item.name, // optional - defaults to feed author property
+        date: item.pubDate.toISOString(), // any format that js Date can parse.
+      });
+    }
+
+    // 保存 rss.xml 文件
+    const rssXmlContent = feed.xml();
+    fs.writeFileSync(rssXmlPath, rssXmlContent, { encoding: 'utf-8' });
+  })();
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "rss": "^1.2.2",
         "rss-parser": "^3.12.0",
+        "seatable-api": "^1.0.42",
         "vue": "^3.2.29"
       },
       "devDependencies": {
@@ -26,6 +27,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
+      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -143,10 +155,49 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.31.tgz",
       "integrity": "sha512-ymN2pj6zEjiKJZbrf98UM2pfDd6F2H7ksKw7NDt/ZZ1fh5Ei39X5tABugtT03ZRlWd9imccoK0hE8hpjpU7irQ=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/csstype": {
       "version": "2.6.19",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
       "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ=="
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "2.2.0",
@@ -499,6 +550,38 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -609,6 +692,16 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -663,6 +756,16 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "node_modules/seatable-api": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/seatable-api/-/seatable-api-1.0.42.tgz",
+      "integrity": "sha512-zooM+8AbYywvhoaeo4D4SmzTddBcfeCQH8wUFF0/M+1mCDupmavozpjwKL0/+A6saeUvV7/yvFc5wFP7UKv1eQ==",
+      "dependencies": {
+        "@babel/runtime": "7.20.13",
+        "axios": "~1.7.*",
+        "dayjs": "1.10.7"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -778,6 +881,14 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
       "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw=="
     },
+    "@babel/runtime": {
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
+      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.11"
+      }
+    },
     "@vitejs/plugin-vue": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.2.0.tgz",
@@ -884,10 +995,43 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.31.tgz",
       "integrity": "sha512-ymN2pj6zEjiKJZbrf98UM2pfDd6F2H7ksKw7NDt/ZZ1fh5Ei39X5tABugtT03ZRlWd9imccoK0hE8hpjpU7irQ=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "requires": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "csstype": {
       "version": "2.6.19",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
       "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ=="
+    },
+    "dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "entities": {
       "version": "2.2.0",
@@ -1059,6 +1203,21 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
+    "follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+    },
+    "form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1137,6 +1296,16 @@
         "source-map-js": "^1.0.2"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -1179,6 +1348,16 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "seatable-api": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/seatable-api/-/seatable-api-1.0.42.tgz",
+      "integrity": "sha512-zooM+8AbYywvhoaeo4D4SmzTddBcfeCQH8wUFF0/M+1mCDupmavozpjwKL0/+A6saeUvV7/yvFc5wFP7UKv1eQ==",
+      "requires": {
+        "@babel/runtime": "7.20.13",
+        "axios": "~1.7.*",
+        "dayjs": "1.10.7"
+      }
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "rss": "^1.2.2",
     "rss-parser": "^3.12.0",
+    "seatable-api": "^1.0.42",
     "vue": "^3.2.29"
   },
   "devDependencies": {


### PR DESCRIPTION
Seatable支持需要额外在secrets中配置`SEATABLE_API_TOKEN`，只读权限即可。

现在的逻辑是先从README里面获取`opmlJson`，然后在Seatable中查找**Name**未在README中的数据加入其中。（并不会检查数据是否更新）

具体实现逻辑应该如何还请@OrangeX4 定夺吧。